### PR TITLE
fixed fpm.toml due to repo reorganization

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -18,6 +18,11 @@ source-dir = "src"
 library = true
 
 [[test]]
-name = "test"
-source-dir = "src/tests"
-main = "test.f90"
+name = "test_CR3BP"
+source-dir = "tests"
+main = "test_CR3BP.f90"
+
+[[test]]
+name = "test_Lorenz"
+source-dir = "tests"
+main = "test_Lorenz.f90"


### PR DESCRIPTION
A fix so that `fpm test` will work again, since the `tests` directory was moved.