### PR TITLE
Fixed fpm.toml (like Jacob Williams), and other small errors.

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -18,6 +18,11 @@ source-dir = "src"
 library = true
 
 [[test]]
-name = "test"
-source-dir = "src/tests"
-main = "test.f90"
+name = "test_Lorenz"
+source-dir = "tests"
+main = "test_Lorenz.f90"
+
+[[test]]
+name = "test_CR3BP"
+source-dir = "tests"
+main = "test_CR3BP.f90"

--- a/src/ButcherTableaus.f90
+++ b/src/ButcherTableaus.f90
@@ -421,6 +421,7 @@ real(WP), parameter :: DOP853_a(1:*) = [ &
 !> Coefficients for 7th-order interpolation
 
 !> Non-zero coefficients for non-zero stages
+integer :: i
 integer, parameter :: DOP853_di_NZ(*) = [1,(i,i=6,16)]
 integer, parameter :: DOP853_dj_NZ(*) = [4,5,6,7]
 

--- a/src/ERKInit.f90
+++ b/src/ERKInit.f90
@@ -290,7 +290,7 @@
             ! check if dense output states are specified, else use all
             ! If events are enabled, we save the coefficients for dense output 
             ! for all states by default
-            if (present(InterpStates) .AND. (.Not. EventsOn)) then
+            if (present(InterpStates) .AND. (.Not. me%EventsOn)) then
                 ! check for valid components
                 if (size(InterpStates) < 1 .OR. size(InterpStates) > me%pDiffEqSys%n &
                     .OR. any(InterpStates < 1) .OR. any(InterpStates > me%pDiffEqSys%n)) then

--- a/src/FLINT_base.f90
+++ b/src/FLINT_base.f90
@@ -316,7 +316,7 @@ module FLINT_base
         subroutine Init(me, DE, MaxSteps, Method, ATOl, RTol, InterpOn, InterpStates, &
             MinStepSize, MaxStepSize, StepSzParams, EventsOn, EventStepSz, EventOptions, EventTol)
 
-            import :: FLINT_class, DiffEqSys, WP
+            import :: FLINT_class, DiffEqSys, WP, FLINT_EVENTOPTION_ROOTFINDING
         
             class(FLINT_class), intent(inout) :: me !< Object
             
@@ -500,7 +500,7 @@ module FLINT_base
         subroutine Info(me, LastStatus, StatusMsg, nSteps, nAccept, nReject, nFCalls, &
                                 InterpReady, h0, X0, Y0, hf, Xf, Yf)
 
-            import :: FLINT_class, WP
+            import :: FLINT_class, WP, FLINT_SUCCESS
         
             class(FLINT_class), intent(inout) :: me !< Object of class type FLINT
             


### PR DESCRIPTION
I'm using gfotran version 11.4 on WSL2. 
The first one is the fix of fpm.toml as that already proposed by Jacob Williams.
In: src/ButcherTableaus.f90 the compiler complained about the variable "i" not being defined. So I added it.
In: src/ERKInit.f90 I think that one should use the components EventsOn belonging to the user defined type "me". I got a segmentation otherwise.
In: src/FLINT_base.f90 one have to add those enumerable to the imports. Well it wasn't compiling without.